### PR TITLE
feat - see note details and delete note

### DIFF
--- a/app/src/main/java/com/example/notesapp/ui/AddNoteActivity.kt
+++ b/app/src/main/java/com/example/notesapp/ui/AddNoteActivity.kt
@@ -52,6 +52,7 @@ class AddNoteActivity : ComponentActivity() {
             .addOnSuccessListener { documentReference ->
                 Toast.makeText(this, "Note added", Toast.LENGTH_SHORT).show()
                 Log.d(TAG, "DocumentSnapshot added with ID: ${documentReference.id}")
+                finish()
             }
             .addOnFailureListener { e ->
                 Toast.makeText(this, "Error adding note", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/notesapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/notesapp/ui/MainActivity.kt
@@ -19,6 +19,7 @@ class MainActivity : ComponentActivity() {
     private lateinit var listView: ListView
     private lateinit var noteAdapter: NoteAdapter
     private val noteList = ArrayList<Note>()
+    private val ids = ArrayList<String>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,6 +53,7 @@ class MainActivity : ComponentActivity() {
                     noteList.clear()
 
                     for (document in snapshots) {
+                        ids.add(document.id)
                         val title = document.getString("title") ?: "Untitled"
                         val content = document.getString("content") ?: "No content"
                         val timestamp = document.getString("timestamp") ?: System.currentTimeMillis().toString()
@@ -73,6 +75,7 @@ class MainActivity : ComponentActivity() {
             val intent = Intent(this, NoteDetailsActivity::class.java)
 
             intent.putExtra("NOTE", clickedNote)
+            intent.putExtra("NOTE_ID", ids[position])
 
             startActivity(intent)
         }

--- a/app/src/main/java/com/example/notesapp/ui/NoteDetailsActivity.kt
+++ b/app/src/main/java/com/example/notesapp/ui/NoteDetailsActivity.kt
@@ -1,0 +1,46 @@
+package com.example.notesapp.ui
+
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import com.example.notesapp.R
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+import com.example.notesapp.models.Note
+
+private const val TAG = "NoteDetailsActivity"
+
+class NoteDetailsActivity : ComponentActivity() {
+    private val db = Firebase.firestore
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_detail)
+
+        @Suppress("DEPRECATION") val note: Note? = intent.getParcelableExtra("NOTE")
+
+        Log.d(TAG, "$note")
+
+        val textView: TextView = findViewById(R.id.noteDetails)
+        val titleTextView: TextView = findViewById(R.id.detailTextView)
+        titleTextView.text = note?.title
+        textView.text = note?.content
+    }
+
+    fun onDelete(view: View) {
+        val noteId = intent.getStringExtra("NOTE_ID")
+        if (noteId != null) {
+            db.collection("notes").document(noteId)
+                .delete()
+                .addOnSuccessListener {
+                    Log.d(TAG, "DocumentSnapshot successfully deleted!")
+                    Toast.makeText(this, "Note deleted", Toast.LENGTH_SHORT).show()
+                    finish()
+                }
+                .addOnFailureListener { e -> Log.w(TAG, "Error deleting document", e) }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -31,6 +31,7 @@
         android:id="@+id/deleteButton"
         android:layout_width="match_parent"
         android:layout_height="50dp"
-        android:text="@string/delete" />
+        android:text="@string/delete"
+        android:onClick="onDelete"/>
 
 </LinearLayout>


### PR DESCRIPTION
### Layout
**activity_detail.xml:** add onClick to delete button
### UI
**NoteDetailsActivity.kt:** display the note's title, content with a delete button that deletes the viewed note from Firestore and navigates back to MainActivity
**MainActivity.kt:** pass the clicked note's id to NoteDetailsActivity with the intent so the user can delete the note
**AddNoteActivity.kt:** call finish() after successfully saving note to Firestore to navigate back to MainActivity